### PR TITLE
added bapc redirect

### DIFF
--- a/ingress/ch.yaml
+++ b/ingress/ch.yaml
@@ -132,6 +132,22 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
+    nginx.ingress.kubernetes.io/temporal-redirect: https://2020.bapc.eu
+  name: redirect-bapc
+  namespace: default
+spec:
+  rules:
+  - host: www.bapc.eu
+  tls:
+  - hosts:
+    - www.bapc.eu
+    - bapc.eu
+    secretName: ingress-ext-tls
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  annotations:
     nginx.ingress.kubernetes.io/temporal-redirect: https://ch.tudelft.nl
   name: redirect-ch
   namespace: default


### PR DESCRIPTION
Goal of this PR is to have bapc.eu or www.bapc.eu redirect to 2020.bapc.eu. I have had contact with the person that can make the domain redirect to our Rob, however I need to make sure this works too.