### PR TITLE
Add HackDelft 2022

### DIFF
--- a/hackdelft/2022/deploy.yaml
+++ b/hackdelft/2022/deploy.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hackdelft-2022
+  namespace: hackdelft
+  labels:
+    app: hackdelft-2022
+  annotations:
+    fluxcd.io/automated: "true"
+spec:
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: hackdelft-2022
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+  template:
+    metadata:
+      name: hackdelft-2022
+      labels:
+        app: hackdelft-2022
+    spec:
+      containers:
+        - name: hackdelft-2022
+          image: ghcr.io/wisvch/hackdelft-2022:20211218-4cbd527
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          resources:
+            limits:
+              memory: 64Mi
+            requests:
+              cpu: 10m
+              memory: 32Mi
+          securityContext:
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          volumeMounts:
+            - name: tmpfs
+              mountPath: /tmp
+      volumes:
+        - name: tmpfs
+          emptyDir:
+            medium: Memory

--- a/hackdelft/2022/service.yaml
+++ b/hackdelft/2022/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: hackdelft-2022
+  name: hackdelft-2022
+  namespace: hackdelft
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+  selector:
+    app: hackdelft-2022
+  sessionAffinity: None
+  type: ClusterIP

--- a/hackdelft/ingress.yaml
+++ b/hackdelft/ingress.yaml
@@ -1,9 +1,7 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  annotations:
-    nginx.ingress.kubernetes.io/temporal-redirect: https://2019.hackdelft.nl
-  name: hackdelft-redirect
+  name: hackdelft
   namespace: hackdelft
 spec:
   rules:
@@ -11,29 +9,20 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: hackdelft-2019
+              serviceName: hackdelft-2022
               servicePort: http
     - host: hackdelft.com
       http:
         paths:
           - backend:
-              serviceName: hackdelft-2019
+              serviceName: hackdelft-2022
               servicePort: http
-  tls:
-    - hosts:
-        - hackdelft.nl
-        - hackdelft.com
-        - www.hackdelft.com
-        - www.hackdelft.nl
-      secretName: ingress-ext-tls
----
-apiVersion: networking.k8s.io/v1beta1
-kind: Ingress
-metadata:
-  name: hackdelft
-  namespace: hackdelft
-spec:
-  rules:
+    - host: 2022.hackdelft.nl
+      http:
+        paths:
+          - backend:
+              serviceName: hackdelft-2022
+              servicePort: http
     - host: 2019.hackdelft.nl
       http:
         paths:
@@ -54,6 +43,11 @@ spec:
               servicePort: http
   tls:
     - hosts:
+        - hackdelft.nl
+        - hackdelft.com
+        - www.hackdelft.com
+        - www.hackdelft.nl
+        - 2022.hackdelft.nl
         - 2019.hackdelft.nl
         - 2018.hackdelft.nl
         - 2017.hackdelft.nl
@@ -67,13 +61,14 @@ metadata:
 spec:
   secretName: ingress-ext-tls
   dnsNames:
-  - hackdelft.nl
-  - hackdelft.com
-  - www.hackdelft.com
-  - www.hackdelft.nl
-  - 2019.hackdelft.nl
-  - 2018.hackdelft.nl
-  - 2017.hackdelft.nl
+    - hackdelft.nl
+    - hackdelft.com
+    - www.hackdelft.com
+    - www.hackdelft.nl
+    - 2022.hackdelft.nl
+    - 2019.hackdelft.nl
+    - 2018.hackdelft.nl
+    - 2017.hackdelft.nl
   issuerRef:
     kind: ClusterIssuer
     name: letsencrypt-prod


### PR DESCRIPTION
The YAML is based on the definitions from 2019.

- Remove redirect to 2019.
- Combines the two ingresses, as it doesn't have a purpose now.
- Add `2022.hackdelft.nl` certificate.