### PR TITLE
Attempt 2 at fixing www.nwerc.eu

### DIFF
--- a/nwerc/ingress.yaml
+++ b/nwerc/ingress.yaml
@@ -22,16 +22,17 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    nginx.ingress.kubernetes.io/from-to-www-redirect: "true"
     nginx.ingress.kubernetes.io/temporal-redirect: https://2022.nwerc.eu
   name: redirect-nwerc
   namespace: default
 spec:
   rules:
   - host: nwerc.eu
+  - host: www.nwerc.eu
   tls:
   - hosts:
     - nwerc.eu
+    - www.nwerc.eu
     secretName: ingress-ext-tls
 ---
 apiVersion: cert-manager.io/v1alpha2


### PR DESCRIPTION
Change from using www annotation for nwerc.eu to just doing it with a temporal redirect

I guess that the combination of `nginx.ingress.kubernetes.io/from-to-www-redirect: "true"` and `nginx.ingress.kubernetes.io/temporal-redirect: https://2022.nwerc.eu` doesn't do what I expected :(.