### PR TITLE
Add rest of uri to NWERC redirect

### DIFF
--- a/nwerc/ingress.yaml
+++ b/nwerc/ingress.yaml
@@ -22,7 +22,7 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    nginx.ingress.kubernetes.io/temporal-redirect: https://2022.nwerc.eu
+    nginx.ingress.kubernetes.io/temporal-redirect: https://2022.nwerc.eu$request_uri
   name: redirect-nwerc
   namespace: default
 spec:


### PR DESCRIPTION
I hope this adds the rest of the URI to the redirect, so that http://nwerc.eu/cfp redirects to http://2022.nwerc.eu/cfp instead of http://2022.nwerc.eu/.